### PR TITLE
docs: fix broken url and reword sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 This is a fork of [nitawa](https://github.com/nitawa-hl)'s
-hatlike tracker for [competitions on hanab.live](hanabi-competitions.com).
+hatlike tracker for [hanabi competitions](https://hanabi-competitions.com).
 
 ## What are hatlike plays?
 


### PR DESCRIPTION
The competitions are associated with hanab.live only so far as it's the preferred website for playing Hanabi.